### PR TITLE
Implement API login routes

### DIFF
--- a/backend/app/Actions/CreateNewUser.php
+++ b/backend/app/Actions/CreateNewUser.php
@@ -1,5 +1,24 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
+
+class CreateNewUser implements CreatesNewUsers
 {
-  "name": "harrys",
-  "password": "12345678",
-  "password_confirmation": "12345678"
+    public function create(array $input): User
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255', 'unique:users'],
+            'password' => ['required', 'string', 'min:8'],
+        ])->validate();
+
+        return User::create([
+            'name' => $input['name'],
+            'password' => Hash::make($input['password']),
+        ]);
+    }
 }

--- a/backend/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/backend/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,30 +1,32 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Auth;
 
+use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
 
-class AuthControlleRegisteredUserControllerr extends Controller
+class RegisteredUserController extends Controller
 {
     public function register(Request $request)
     {
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:1'],
-            
         ]);
 
         $user = User::create([
             'name' => $validated['name'],
             'password' => Hash::make($validated['password']),
-           
         ]);
 
         Auth::login($user);
 
-        return response()->json(['message' => 'Registrierung erfolgreich', 'user' => $user]);
+        return response()->json([
+            'message' => 'Registrierung erfolgreich',
+            'user' => $user,
+        ]);
     }
-};
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,7 +1,13 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\AuthController;
+use Illuminate\Http\Request;
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\RegisteredUserController;
+
+Route::post('/login', [AuthenticatedSessionController::class, 'store']);
+Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])->middleware('auth:sanctum');
+Route::post('/register', [RegisteredUserController::class, 'register']);
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();

--- a/frontend/src/stores/userStore.js
+++ b/frontend/src/stores/userStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import api from "../api/api";
+import axios from "axios";
 
 export const useUserStore = defineStore("user", {
   state: () => ({
@@ -18,7 +19,7 @@ export const useUserStore = defineStore("user", {
     },
     async login(credentials) {
       try {
-        await api.get("/sanctum/csrf-cookie"); // für Sanctum
+        await axios.get("http://localhost:8000/sanctum/csrf-cookie", { withCredentials: true });
         await api.post("/login", credentials);
         await this.fetchUser();
       } catch (err) {

--- a/frontend/src/views/auth/LoginPage.vue
+++ b/frontend/src/views/auth/LoginPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue'
 import axios from 'axios'
+import api from "../api/api"
 
 const name = ref('')
 const password = ref('')
@@ -14,19 +15,15 @@ async function login() {
     })
 
     // 2. Login
-    await axios.post('http://localhost:8000/login', {
+    await api.post('/login', {
       name: name.value,
       password: password.value
-    }, {
-      withCredentials: true
     })
 
     message.value = '✅ Login erfolgreich'
 
     // 3. User abfragen (optional)
-    const res = await axios.get('http://localhost:8000/api/user', {
-      withCredentials: true
-    })
+    const res = await api.get('/user')
 
     console.log('Eingeloggt als:', res.data)
 

--- a/frontend/src/views/auth/RegistriPag.vue
+++ b/frontend/src/views/auth/RegistriPag.vue
@@ -54,6 +54,7 @@
 
 <script>
 import axios from 'axios';
+import api from '@/api/api';
 
 export default {
   name: 'RegistriPag',
@@ -86,8 +87,8 @@ export default {
       }
 
       try {
-        const response = await axios.post('http://localhost:8000/api/register', {
-          username: this.formData.username,
+        const response = await api.post('/register', {
+          name: this.formData.username,
           password: this.formData.password
         });
 


### PR DESCRIPTION
## Summary
- support API login/register/logout endpoints
- implement a proper registration controller and user creation action
- update frontend login and registration to call API
- fix Pinia user store to fetch CSRF cookie correctly

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `php backend/vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb6e6aa208331bf742d36d0e2de6e